### PR TITLE
Prevent exception when joining an invoked queue

### DIFF
--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -11,17 +11,17 @@ import { getGuildId, getChannel } from '../utils/getters';
 export const data = new SlashCommandBuilder()
   .setName('queue')
   .setDescription('ShortStack queue')
-  .addSubcommand(subcommand =>
+  .addSubcommand((subcommand) =>
     subcommand
       .setName(QUEUE_OPTIONS.join)
       .setDescription('Join the Dota 2 queue!')
   )
-  .addSubcommand(subcommand =>
+  .addSubcommand((subcommand) =>
     subcommand
       .setName(QUEUE_OPTIONS.leave)
       .setDescription('Leave the Dota 2 queue!')
   )
-  .addSubcommand(subcommand =>
+  .addSubcommand((subcommand) =>
     subcommand
       .setName(QUEUE_OPTIONS.invoke)
       .setDescription('Invoke the Dota 2 queue!')
@@ -54,14 +54,16 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
       interaction.reply(
         `You're in! Queue looks like this:\n${guildSettings.queue.join('\n')}`
       );
+      await guildSettings.save();
       break;
     case QUEUE_OPTIONS.leave:
       guildSettings.queue = guildSettings.queue.filter(
-        user => user !== interaction.user.toString()
+        (user) => user !== interaction.user.toString()
       );
       interaction.reply(
         `You're out! Queue looks like this:\n${guildSettings.queue.join('\n')}`
       );
+      await guildSettings.save();
       break;
     case QUEUE_OPTIONS.invoke:
       if (guildSettings.queue.length < 1)
@@ -80,16 +82,19 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
           guildSettings.queue,
           invokeesNeeded
         );
-        guildSettings.queue = guildSettings.queue.filter(
-          queuerId => !toRemove.some(({ id }) => id === queuerId)
+        const postInvokeGuildSettings = await getGuildFromDb(guildId);
+        postInvokeGuildSettings.queue = postInvokeGuildSettings.queue.filter(
+          (queuerId) => !toRemove.some(({ id }) => id === queuerId)
         );
+
+        await postInvokeGuildSettings.save();
         break;
       }
       interaction.reply({
         content: 'That is not an appropriate number for a Dota 2 party!',
         ephemeral: true,
       });
+
       break;
   }
-  await guildSettings.save();
 };


### PR DESCRIPTION
Concurrency issues in mongo DB would cause an exception to be thrown when attempting to join the queue during an ongoing invoke. This because we attempt to save an outdated queue at the end of the invoke.

**Test**
You need 2 discord accounts:
1. Join the queue with account A
2. Use queue invoke
3. Use /queue join with account B during the queue invoke
4. Press "AND THE QUEUE SHALL ANSWER" as account A

This would previously cause the exception.