### PR TITLE
Modify leave command to allow removing other users

### DIFF
--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -20,6 +20,12 @@ export const data = new SlashCommandBuilder()
     subcommand
       .setName(QUEUE_OPTIONS.leave)
       .setDescription('Leave the Dota 2 queue!')
+      .addUserOption((option) =>
+        option
+          .setName('user')
+          .setDescription('Remove another user')
+          .setRequired(false)
+      )
   )
   .addSubcommand((subcommand) =>
     subcommand
@@ -57,12 +63,19 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
       await guildSettings.save();
       break;
     case QUEUE_OPTIONS.leave:
+      const userFromParam = interaction.options.getUser('user');
+      const userToRemove = userFromParam ?? interaction.user;
+
       guildSettings.queue = guildSettings.queue.filter(
-        (user) => user !== interaction.user.toString()
+        (user) => user !== userToRemove.toString()
       );
+      const outPronoun = userFromParam ? 'Queuer' : "You're";
       interaction.reply(
-        `You're out! Queue looks like this:\n${guildSettings.queue.join('\n')}`
+        `${outPronoun} out! Queue looks like this:\n${guildSettings.queue.join(
+          '\n'
+        )}`
       );
+
       await guildSettings.save();
       break;
     case QUEUE_OPTIONS.invoke:


### PR DESCRIPTION
If a queuer for example joins the stack without a proper invoke, they can now be removed by other users using an optional parameter in the /queue leave command.

**Test**
You need 2 discord accounts:
1. Join the queue with account A
2. Use /queue leave with the optional parameter targeting account A using account B
3. Account A should be removed from queue

Using queue leave without a parameter should work as before.