### PR TITLE
Ping queued users when invoking queue

### DIFF
--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -76,7 +76,9 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
           guildSettings.yaposChannel,
           interaction
         );
-        const message = await channel.send('Setting up...');
+        const message = await channel.send(
+          `Setting up invoke for ${guildSettings.queue.join(' ')}`
+        );
         const toRemove = await invokeMessageCollector(
           message,
           guildSettings.queue,


### PR DESCRIPTION
If a message is edited to include users, the users will not receive a notification. This will include users when the original message is sent.

**Test**
You need 2 discord accounts:
1. Join the queue with account A
2. Use /queue invoke with account B
3. Make sure that account A received a notification