### PR TITLE
Prevent queue join and queue leave from pinging queuers

### DIFF
--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -57,9 +57,12 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
         break;
       }
       guildSettings.queue.push(interaction.user.toString());
-      interaction.reply(
-        `You're in! Queue looks like this:\n${guildSettings.queue.join('\n')}`
-      );
+      interaction.reply({
+        content: `You're in! Queue looks like this:\n${guildSettings.queue.join(
+          '\n'
+        )}`,
+        allowedMentions: { parse: [] },
+      });
       await guildSettings.save();
       break;
     case QUEUE_OPTIONS.leave:
@@ -70,12 +73,12 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
         (user) => user !== userToRemove.toString()
       );
       const outPronoun = userFromParam ? 'Queuer' : "You're";
-      interaction.reply(
-        `${outPronoun} out! Queue looks like this:\n${guildSettings.queue.join(
+      interaction.reply({
+        content: `${outPronoun} out! Queue looks like this:\n${guildSettings.queue.join(
           '\n'
-        )}`
-      );
-
+        )}`,
+        allowedMentions: { parse: [] },
+      });
       await guildSettings.save();
       break;
     case QUEUE_OPTIONS.invoke:


### PR DESCRIPTION
This will prevent queuers from being pinged when a user joins or leaves the queue.

**Test**
You need 2 discord accounts:
1. Join the queue with account A
2. Join the queue with account B and make sure that account A did not receive a notification
3. Leave the queue with either user and make sure that the other did not receive a notification