### PR TITLE
Updated max value of time for lfs from 60 to 120

### DIFF
--- a/src/commands/lfs.ts
+++ b/src/commands/lfs.ts
@@ -25,7 +25,7 @@ export const data = new SlashCommandBuilder()
       .setDescription('How long can you wait for a Stack?')
       .setRequired(false)
       .setMinValue(5)
-      .setMaxValue(60)
+      .setMaxValue(120)
   );
 
 export const execute = async (interaction: ChatInputCommandInteraction) => {


### PR DESCRIPTION
Is there a technical reason why the max duration is 60? I think not but maybe there is some discord thing that only enables these embeds to be "live" for an hour?
Sometimes you know you will sit at the computer for a long time and it's a hassle to redo the stack once an hour imo