### PR TITLE
Queue user interactions

### DIFF
--- a/src/commands/lfs/lobby.ts
+++ b/src/commands/lfs/lobby.ts
@@ -1,10 +1,12 @@
 import {
   AnyThreadChannel,
+  ButtonInteraction,
   ChatInputCommandInteraction,
   CollectedInteraction,
   CollectedMessageInteraction,
   ComponentType,
   Message,
+  ModalMessageModalSubmitInteraction,
   User,
 } from 'discord.js';
 import { getGuildFromDb, getUserPrefs } from '../../database/db';
@@ -30,6 +32,7 @@ import {
   PlayerObject,
 } from '../../utils/types';
 import { createButtonRow } from '../../utils/view';
+import { SerialQueue, ackAndDiscard } from '../../utils/interactionQueue';
 import { stackSetup } from '../stack/stacking';
 import {
   createDummy,
@@ -42,9 +45,11 @@ import {
 import { getDummyNameModal, condiModal } from './modals';
 import { createStackButtons, lobbyEmbed, rdyButtons, readyEmbed } from './view';
 
+const STRAY_CLICK_GRACE = 3000;
+
 export const setUp = async (
   interaction: ChatInputCommandInteraction,
-  confirmedPlayers: ConfirmedPlayer[]
+  confirmedPlayers: ConfirmedPlayer[],
 ) => {
   const guildId = getGuildId(interaction);
   const condiPlayers: ConditionalPlayer[] = [];
@@ -64,7 +69,7 @@ export const setUp = async (
     content: setUpMessageContent(
       roleCall,
       time + timeLimit,
-      guildSettings.queue
+      guildSettings.queue,
     ),
     embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
     components: createStackButtons(),
@@ -76,10 +81,10 @@ export const setUp = async (
   const partyThread = await pThreadCreator(interaction, dotaMessage);
   const confirmedPlayersWithoutDummies = confirmedPlayers.filter(
     (p): p is { user: User; preferences: string[]; nickname: string } =>
-      !('isDummy' in p)
+      !('isDummy' in p),
   );
   confirmedPlayersWithoutDummies.forEach((p) =>
-    partyThread.members.add(p.user)
+    partyThread.members.add(p.user),
   );
   if (confirmedPlayers.length === 5) {
     await dotaMessage.edit({
@@ -98,117 +103,199 @@ export const setUp = async (
     componentType: ComponentType.Button,
   });
   console.log('setUp: on collect');
-  collector.on('collect', async (i) => {
-    console.log(`${i.user.username} clicked ${i.customId}`);
-    switch (i.customId) {
-      case STACK_BUTTONS.join.btnId:
-        if (!confirmedPlayers.some(({ user }) => user.id === i.user.id)) {
-          removeFromArray(condiPlayers, i);
-          const nickname = await getNickname(i, i.user);
-          const preferences = await getUserPrefs(i.user.id);
-          confirmedPlayers.push({ user: i.user, preferences, nickname });
-          await partyThread.members.add(i.user);
-          if (confirmedPlayers.length === 5) {
-            await i.update({
-              embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
-              components: [createButtonRow(READY_TO_READY_BUTTON)],
-            });
-            console.log('Stopping from', STACK_BUTTONS.join.btnId);
-          }
-        }
-        break;
+  const lobbyQueue = new SerialQueue();
+  let joinPhaseLocked = confirmedPlayers.length >= 5;
+  let readyStarted = false;
 
-      case STACK_BUTTONS.condi.btnId:
-        if (!condiPlayers.some(({ user }) => user.id === i.user.id)) {
-          const modalInteraction = await condiModal(i);
-          if (!modalInteraction) {
-            console.log(
-              'falsy modal interaction, likely from opening and cancelling the modal'
-            );
-            break;
-          }
-          if (!modalInteraction.isFromMessage())
-            throw new Error("Somehow this modal isn't from a message");
-          const time = getTimestamp(1000);
-          const condition = `${modalInteraction.fields.getTextInputValue(
-            'reason'
-          )} *(written <t:${time}:R>)*`;
-          const nickname = await getNickname(interaction, interaction.user);
-          const preferences = await getUserPrefs(i.user.id);
-          condiPlayers.push({
-            user: i.user,
-            nickname,
-            preferences,
-            condition: condition,
-          });
-          removeFromArray(confirmedPlayers, i);
-          await modalInteraction.update({
+  const startReadyChecker = async (i: ButtonInteraction) => {
+    await ackAndDiscard(i);
+    readyChecker(confirmedPlayers, dotaMessage, partyThread);
+    setTimeout(() => collector.stop(), STRAY_CLICK_GRACE);
+  };
+
+  const handleLobbyButton = async (i: ButtonInteraction) => {
+    if (joinPhaseLocked) {
+      await ackAndDiscard(i);
+      return;
+    }
+    switch (i.customId) {
+      case STACK_BUTTONS.join.btnId: {
+        if (confirmedPlayers.some(({ user }) => user.id === i.user.id)) {
+          await i.update({
             embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
           });
+          return;
         }
-        break;
-
-      case STACK_BUTTONS.dummy.btnId:
-        const modalInteraction = await getDummyNameModal(i);
-        if (!modalInteraction) {
-          console.log(
-            'falsy modal interaction, likely from opening and closing the modal without input',
-            modalInteraction
-          );
-          break;
+        if (confirmedPlayers.length >= 5) {
+          await ackAndDiscard(i);
+          return;
         }
-        if (!modalInteraction.isFromMessage())
-          throw new Error('Somehow modalInteraction is not from message');
-
-        const dummyName =
-          modalInteraction.fields.getTextInputValue('dummyName');
-        if (!dummyName) break;
-        const dummy = await createDummy(dummyName, i);
-        if (
-          confirmedPlayers.some(({ user }) => user.id === dummy.user.id) ||
-          condiPlayers.some(({ user }) => user.id === dummy.user.id)
-        ) {
-          await modalInteraction.reply({
-            content: `${dummyName} is already accounted for, as ${dummy.nickname}!`,
-            ephemeral: true,
-          });
-          break;
-        }
-        if (dummy.user instanceof User) {
-          await partyThread.members.add(dummy.user);
-        }
-        confirmedPlayers.push(dummy);
-        if (confirmedPlayers.length === 5) {
-          console.log('Stopping from withing dummy');
-          await modalInteraction.update({
+        removeFromArray(condiPlayers, i);
+        const nickname = await getNickname(i, i.user);
+        const preferences = await getUserPrefs(i.user.id);
+        confirmedPlayers.push({ user: i.user, preferences, nickname });
+        await partyThread.members.add(i.user);
+        if (confirmedPlayers.length >= 5) {
+          joinPhaseLocked = true;
+          await i.update({
             embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
             components: [createButtonRow(READY_TO_READY_BUTTON)],
           });
-          break;
+          return;
         }
-        await modalInteraction.update({
+        await i.update({
           embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
         });
-        break;
+        return;
+      }
 
       case STACK_BUTTONS.leave.btnId:
         removeFromArray(condiPlayers, i);
         removeFromArray(confirmedPlayers, i);
-        break;
+        await i.update({
+          embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
+        });
+        return;
+    }
+  };
 
-      case READY_TO_READY_BUTTON.btnId:
-        collector.stop();
-        break;
+  const addCondiPlayer = async (
+    i: ButtonInteraction,
+    modalInteraction: ModalMessageModalSubmitInteraction,
+  ) => {
+    if (joinPhaseLocked) {
+      await ackAndDiscard(modalInteraction);
+      return;
     }
-    if (!i.replied) {
-      await i.update({
-        embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
+    const time = getTimestamp(1000);
+    const condition = `${modalInteraction.fields.getTextInputValue(
+      'reason',
+    )} *(written <t:${time}:R>)*`;
+    const nickname = await getNickname(interaction, interaction.user);
+    const preferences = await getUserPrefs(i.user.id);
+    condiPlayers.push({
+      user: i.user,
+      nickname,
+      preferences,
+      condition: condition,
+    });
+    removeFromArray(confirmedPlayers, i);
+    await modalInteraction.update({
+      embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
+    });
+  };
+
+  const addDummyPlayer = async (
+    dummyName: string,
+    dummy: ConfirmedPlayer,
+    modalInteraction: ModalMessageModalSubmitInteraction,
+  ) => {
+    if (
+      confirmedPlayers.some(({ user }) => user.id === dummy.user.id) ||
+      condiPlayers.some(({ user }) => user.id === dummy.user.id)
+    ) {
+      await modalInteraction.reply({
+        content: `${dummyName} is already accounted for, as ${dummy.nickname}!`,
+        ephemeral: true,
       });
+      return;
     }
+    if (joinPhaseLocked || confirmedPlayers.length >= 5) {
+      await ackAndDiscard(modalInteraction);
+      return;
+    }
+    if (dummy.user instanceof User) {
+      await partyThread.members.add(dummy.user);
+    }
+    confirmedPlayers.push(dummy);
+    if (confirmedPlayers.length >= 5) {
+      joinPhaseLocked = true;
+      await modalInteraction.update({
+        embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
+        components: [createButtonRow(READY_TO_READY_BUTTON)],
+      });
+      return;
+    }
+    await modalInteraction.update({
+      embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
+    });
+  };
+
+  const handleModalButton = async (i: ButtonInteraction) => {
+    if (i.customId === STACK_BUTTONS.condi.btnId) {
+      if (condiPlayers.some(({ user }) => user.id === i.user.id)) {
+        await ackAndDiscard(i);
+        return;
+      }
+      const modalInteraction = await condiModal(i);
+      if (!modalInteraction) {
+        console.log(
+          'falsy modal interaction, likely from opening and cancelling the modal',
+        );
+        return;
+      }
+      if (!modalInteraction.isFromMessage())
+        throw new Error("Somehow this modal isn't from a message");
+      await lobbyQueue.add(() => addCondiPlayer(i, modalInteraction));
+      return;
+    }
+
+    const modalInteraction = await getDummyNameModal(i);
+    if (!modalInteraction) {
+      console.log(
+        'falsy modal interaction, likely from opening and closing the modal without input',
+        modalInteraction,
+      );
+      return;
+    }
+    if (!modalInteraction.isFromMessage())
+      throw new Error('Somehow modalInteraction is not from message');
+    const dummyName = modalInteraction.fields.getTextInputValue('dummyName');
+    if (!dummyName) {
+      await ackAndDiscard(modalInteraction);
+      return;
+    }
+    const dummy = await createDummy(dummyName, i);
+    await lobbyQueue.add(() =>
+      addDummyPlayer(dummyName, dummy, modalInteraction),
+    );
+  };
+
+  collector.on('collect', (i) => {
+    console.log(`${i.user.username} clicked ${i.customId}`);
+    if (i.customId === READY_TO_READY_BUTTON.btnId) {
+      if (readyStarted) {
+        void ackAndDiscard(i);
+        return;
+      }
+      readyStarted = true;
+      void startReadyChecker(i);
+      return;
+    }
+    if (readyStarted || joinPhaseLocked) {
+      void ackAndDiscard(i);
+      return;
+    }
+    if (
+      i.customId === STACK_BUTTONS.condi.btnId ||
+      i.customId === STACK_BUTTONS.dummy.btnId
+    ) {
+      void handleModalButton(i);
+      return;
+    }
+    void lobbyQueue.add(async () => {
+      try {
+        await handleLobbyButton(i);
+      } catch (error) {
+        console.error('Error handling lobby button', error);
+        await ackAndDiscard(i);
+      }
+    });
   });
 
   console.log('setUp: on end');
   collector.on('end', async () => {
+    if (readyStarted) return;
     if (confirmedPlayers.length < 5) {
       await dotaMessage.edit({
         content: outOfTime,
@@ -218,8 +305,9 @@ export const setUp = async (
       return;
     }
     console.log(
-      'Finishing and starting the ready checker from the ELSE block of the component collector'
+      'Finishing and starting the ready checker from the ELSE block of the component collector',
     );
+    readyStarted = true;
     await dotaMessage.edit({
       content: 'Setting up ready check...',
       components: [],
@@ -232,7 +320,7 @@ export const setUp = async (
 const readyChecker = async (
   confirmedPlayers: ConfirmedPlayer[],
   partyMessage: Message<true>,
-  partyThread: AnyThreadChannel
+  partyThread: AnyThreadChannel,
 ) => {
   console.log('now we are in the ready checker');
   const {
@@ -263,13 +351,19 @@ const readyChecker = async (
     components: rdyButtons(),
   });
   console.log('this is after the edit');
-  collector.on('collect', async (i) => {
+  const readyQueue = new SerialQueue();
+  let readyFinished = false;
+
+  const handleReadyButton = async (i: ButtonInteraction) => {
+    if (readyFinished) {
+      await ackAndDiscard(i);
+      return;
+    }
     const pickTime = getTimestamp(1);
-    console.log(i.user.username + ' clicked ' + i.customId);
     switch (i.customId) {
-      case READY_BUTTONS.rdy.btnId:
+      case READY_BUTTONS.rdy.btnId: {
         const player = readyArray.find(
-          (e) => e.user.id === i.user.id && e.ready === false
+          (e) => e.user.id === i.user.id && e.ready === false,
         );
         if (player) {
           player.ready = true;
@@ -277,33 +371,53 @@ const readyChecker = async (
         }
         if (everyoneReady(readyArray)) {
           console.log('Now stopping');
+          readyFinished = true;
+          await i.update({ embeds: [readyEmbed(readyArray)] });
           collector.stop("That's enough");
+          return;
         }
-        break;
+        await i.update({ embeds: [readyEmbed(readyArray)] });
+        return;
+      }
       case READY_BUTTONS.stop.btnId:
+        readyFinished = true;
+        await i.update({ embeds: [readyEmbed(readyArray)] });
         collector.stop('Someone wants out!');
-        break;
+        return;
       case READY_BUTTONS.sudo.btnId:
+        readyFinished = true;
         forceReady(readyArray, pickTime - miliTime);
+        await i.update({ embeds: [readyEmbed(readyArray)] });
         collector.stop();
-        break;
+        return;
       case READY_BUTTONS.ping.btnId:
         await i.deferUpdate();
         void pingMessage(readyArray, partyThread);
-        break;
+        return;
     }
-    if (!i.deferred) {
-      await i.update({
-        embeds: [readyEmbed(readyArray)],
-      });
+  };
+
+  collector.on('collect', (i) => {
+    console.log(i.user.username + ' clicked ' + i.customId);
+    if (readyFinished) {
+      void ackAndDiscard(i);
+      return;
     }
+    void readyQueue.add(async () => {
+      try {
+        await handleReadyButton(i);
+      } catch (error) {
+        console.error('Error handling ready button', error);
+        await ackAndDiscard(i);
+      }
+    });
   });
 
   collector.on('end', async (collected) => {
     console.log(
       `Now stopping and removing components, the final interaction was: ${
         collected.last() ? collected.last()?.customId : `Nothing!`
-      }`
+      }`,
     );
     await partyMessage.edit({
       components: [],
@@ -345,7 +459,7 @@ const readyChecker = async (
 async function redoCollector(
   partyMessage: Message<true>,
   confirmedPlayers: ConfirmedPlayer[],
-  partyThread: AnyThreadChannel
+  partyThread: AnyThreadChannel,
 ) {
   const filter = (i: CollectedInteraction) =>
     i.message?.id === partyMessage.id && i.customId === REDO_BUTTON.btnId;
@@ -374,7 +488,7 @@ async function redoCollector(
 
 async function stackIt(
   message: Message<true>,
-  confirmedPlayers: ConfirmedPlayer[]
+  confirmedPlayers: ConfirmedPlayer[],
 ) {
   const filter = (i: CollectedInteraction) =>
     i.message?.id === message.id && i.customId === STACK_IT_BUTTON.btnId;
@@ -393,7 +507,7 @@ async function stackIt(
       console.log(
         'It is possible that they are actually ready but the interaction is falsy so who knows',
         interaction,
-        collected
+        collected,
       );
 
       await message.edit({

--- a/src/utils/interactionQueue.ts
+++ b/src/utils/interactionQueue.ts
@@ -1,0 +1,38 @@
+import {
+  MessageComponentInteraction,
+  ModalMessageModalSubmitInteraction,
+} from 'discord.js';
+
+type Acknowledgeable =
+  | MessageComponentInteraction
+  | ModalMessageModalSubmitInteraction;
+
+/**
+ * Runs async tasks one at a time, in the order they were added.
+ */
+export class SerialQueue {
+  private tail: Promise<unknown> = Promise.resolve();
+
+  add<T>(task: () => Promise<T>): Promise<T> {
+    const run = this.tail.then(task);
+    this.tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+}
+
+/**
+ * Acknowledge an interaction without changing anything so Discord does not show
+ * "This interaction failed" after 3 seconds. This can be used when 2 users click the same button,
+ *  but only one interaction needs to be processed to achieve the desired result.
+ */
+export const ackAndDiscard = async (interaction: Acknowledgeable) => {
+  if (interaction.replied || interaction.deferred) return;
+  try {
+    await interaction.deferUpdate();
+  } catch (error) {
+    console.error('Failed to acknowledge discarded interaction', error);
+  }
+};


### PR DESCRIPTION
This is based on https://github.com/snygghugo/ShortStack/pull/18. Please merge that one first.

The button and modal interactions towards the LFS could cause a corrupt shared state (for example more than 6 players in a stack) or trigger "This interaction failed" (for example when 2 players clicked "Start Ready Checker" at the same time). This PR uses SerialQueue to process certain events one at a time and ackAndDiscard() to respond to clicks that don't need handling.

List of changed commands:
- I'M IN: Now runs serialized so that 2 people can't join at the same time.
- Add absentee: Also queued and discarded if there are 5 people in the stack already.
- Start Ready Checker: Only execute the logic for the first click. The following clicks are acknowledged and discarded.
- rdy button: Ready toggles are queued. This might fixed the issue that caused the LFS to be stuck at everyone is ready without progressing to picking inshallah.