### PR TITLE
Skip start ready check and remove cancel btn

### DIFF
--- a/src/commands/lfs/lobby.ts
+++ b/src/commands/lfs/lobby.ts
@@ -12,10 +12,8 @@ import {
 import { getGuildFromDb, getUserPrefs } from '../../database/db';
 import {
   READY_BUTTONS,
-  READY_TO_READY_BUTTON,
   REDO_BUTTON,
   STACK_BUTTONS,
-  STACK_IT_BUTTON,
 } from '../../utils/buttons/buttonConsts';
 import {
   FIVEMINUTES,
@@ -87,16 +85,12 @@ export const setUp = async (
     partyThread.members.add(p.user),
   );
   if (confirmedPlayers.length === 5) {
-    await dotaMessage.edit({
-      embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
-      components: [createButtonRow(READY_TO_READY_BUTTON)],
-    });
+    await readyChecker(confirmedPlayers, dotaMessage, partyThread);
+    return;
   }
 
   const filter = (i: CollectedMessageInteraction) =>
-    (i.customId in STACK_BUTTONS ||
-      i.customId === READY_TO_READY_BUTTON.btnId) &&
-    i.message.id === dotaMessage.id;
+    i.customId in STACK_BUTTONS && i.message.id === dotaMessage.id;
   const collector = dotaMessage.createMessageComponentCollector({
     filter,
     time: timeLimit * 1000,
@@ -107,9 +101,13 @@ export const setUp = async (
   let joinPhaseLocked = confirmedPlayers.length >= 5;
   let readyStarted = false;
 
-  const startReadyChecker = async (i: ButtonInteraction) => {
+  const beginReadyCheck = async (
+    i: ButtonInteraction | ModalMessageModalSubmitInteraction,
+  ) => {
+    readyStarted = true;
+    joinPhaseLocked = true;
     await ackAndDiscard(i);
-    readyChecker(confirmedPlayers, dotaMessage, partyThread);
+    await readyChecker(confirmedPlayers, dotaMessage, partyThread);
     setTimeout(() => collector.stop(), STRAY_CLICK_GRACE);
   };
 
@@ -136,11 +134,7 @@ export const setUp = async (
         confirmedPlayers.push({ user: i.user, preferences, nickname });
         await partyThread.members.add(i.user);
         if (confirmedPlayers.length >= 5) {
-          joinPhaseLocked = true;
-          await i.update({
-            embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
-            components: [createButtonRow(READY_TO_READY_BUTTON)],
-          });
+          await beginReadyCheck(i);
           return;
         }
         await i.update({
@@ -209,11 +203,7 @@ export const setUp = async (
     }
     confirmedPlayers.push(dummy);
     if (confirmedPlayers.length >= 5) {
-      joinPhaseLocked = true;
-      await modalInteraction.update({
-        embeds: [lobbyEmbed(confirmedPlayers, condiPlayers)],
-        components: [createButtonRow(READY_TO_READY_BUTTON)],
-      });
+      await beginReadyCheck(modalInteraction);
       return;
     }
     await modalInteraction.update({
@@ -263,15 +253,6 @@ export const setUp = async (
 
   collector.on('collect', (i) => {
     console.log(`${i.user.username} clicked ${i.customId}`);
-    if (i.customId === READY_TO_READY_BUTTON.btnId) {
-      if (readyStarted) {
-        void ackAndDiscard(i);
-        return;
-      }
-      readyStarted = true;
-      void startReadyChecker(i);
-      return;
-    }
     if (readyStarted || joinPhaseLocked) {
       void ackAndDiscard(i);
       return;
@@ -296,24 +277,11 @@ export const setUp = async (
   console.log('setUp: on end');
   collector.on('end', async () => {
     if (readyStarted) return;
-    if (confirmedPlayers.length < 5) {
-      await dotaMessage.edit({
-        content: outOfTime,
-        components: [],
-        embeds: [],
-      });
-      return;
-    }
-    console.log(
-      'Finishing and starting the ready checker from the ELSE block of the component collector',
-    );
-    readyStarted = true;
     await dotaMessage.edit({
-      content: 'Setting up ready check...',
+      content: outOfTime,
       components: [],
       embeds: [],
     });
-    readyChecker(confirmedPlayers, dotaMessage, partyThread);
   });
 };
 
@@ -446,13 +414,37 @@ const readyChecker = async (
       }
     }
 
-    console.log('this is the else block before the stack button is made');
-    const stackButton = createButtonRow(STACK_IT_BUTTON);
+    console.log('Everyone is ready, going straight to stacking');
+    const startInteraction = collected.last();
+    if (!startInteraction) {
+      await partyMessage.edit({
+        content: "You actually don't seem all that ready.",
+      });
+      return;
+    }
     await partyMessage.edit({
       content: finalMessageContent(collected),
-      components: [stackButton],
+      components: [],
     });
-    await stackIt(partyMessage, confirmedPlayers);
+    const playerArray: PlayerObject[] = [];
+    for (const { user, preferences, nickname } of confirmedPlayers) {
+      playerArray.push({
+        user,
+        nickname,
+        position: '',
+        preferences,
+        artTarget: false,
+        fillFlag: false,
+        randomed: 0,
+      });
+    }
+    const shuffledPlayerArray = shuffle(playerArray);
+    await stackSetup(
+      startInteraction,
+      shuffledPlayerArray,
+      STANDARD_TIME,
+      partyMessage,
+    );
   });
 };
 
@@ -483,53 +475,5 @@ async function redoCollector(
       return;
     }
     return;
-  });
-}
-
-async function stackIt(
-  message: Message<true>,
-  confirmedPlayers: ConfirmedPlayer[],
-) {
-  const filter = (i: CollectedInteraction) =>
-    i.message?.id === message.id && i.customId === STACK_IT_BUTTON.btnId;
-  const collector = message.createMessageComponentCollector({
-    filter,
-    time: FIVEMINUTES * 1000,
-    max: 1,
-    componentType: ComponentType.Button,
-  });
-  collector.on('collect', async (i) => {});
-
-  collector.on('end', async (collected) => {
-    await message.edit({ components: [] });
-    const interaction = collected.last();
-    if (!interaction) {
-      console.log(
-        'It is possible that they are actually ready but the interaction is falsy so who knows',
-        interaction,
-        collected,
-      );
-
-      await message.edit({
-        content: "You actually don't seem all that ready.",
-      });
-      return;
-    }
-
-    const playerArray: PlayerObject[] = [];
-
-    for (const { user, preferences, nickname } of confirmedPlayers) {
-      playerArray.push({
-        user,
-        nickname,
-        position: '',
-        preferences,
-        artTarget: false,
-        fillFlag: false,
-        randomed: 0,
-      });
-    }
-    const shuffledPlayerArray = shuffle(playerArray);
-    await stackSetup(interaction, shuffledPlayerArray, STANDARD_TIME, message);
   });
 }

--- a/src/commands/lfs/view.ts
+++ b/src/commands/lfs/view.ts
@@ -33,10 +33,10 @@ export const createStackButtons = () => {
 };
 
 export const rdyButtons = () => {
-  const { rdy, stop, sudo, ping } = READY_BUTTONS;
-  const buttonRow = new ActionRowBuilder<ButtonBuilder>()
-    .addComponents(createButton(rdy))
-    .addComponents(createButton(stop));
+  const { rdy, sudo, ping } = READY_BUTTONS;
+  const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    createButton(rdy),
+  );
   const row2 = new ActionRowBuilder<ButtonBuilder>()
     .addComponents(createButton(sudo))
     .addComponents(createButton(ping));
@@ -45,7 +45,7 @@ export const rdyButtons = () => {
 
 export const lobbyEmbed = (
   confirmedPlayers: ConfirmedPlayer[],
-  condiPlayers: ConditionalPlayer[]
+  condiPlayers: ConditionalPlayer[],
 ) => {
   const { open, dotaQuery, condiHeading } = lobbyEmbedStrings;
   const roles = figureItOut(confirmedPlayers);
@@ -82,7 +82,7 @@ export const lobbyEmbed = (
       //     .join('\n'),
       //   inline: true,
       // },
-      BLANK_FIELD
+      BLANK_FIELD,
     );
   }
 
@@ -91,7 +91,7 @@ export const lobbyEmbed = (
     if (player) {
       playerFields.push(getNameWithPing(player.user).toString());
       preferencesFields.push(
-        player.preferences.map(parsePrefsForEmbed).join(' > ')
+        player.preferences.map(parsePrefsForEmbed).join(' > '),
       );
     } else {
       playerFields.push(open);
@@ -105,12 +105,12 @@ export const lobbyEmbed = (
       name: '*Preferences*',
       value: preferencesFields.join('\n'),
       inline: true,
-    }
+    },
   );
 
   if (condiPlayers.length > 0) {
     const conditionalFields = condiPlayers.map(
-      ({ user, condition }) => `${user} - ${condition}`
+      ({ user, condition }) => `${user} - ${condition}`,
     );
     embedFields.push(BLANK_FIELD);
     embedFields.push({
@@ -145,7 +145,7 @@ export const readyEmbed = (readyArray: PlayerToReady[]) => {
         name: BLANK,
         value: readyArray
           .map(({ ready, pickTime }) =>
-            ready ? `✅ \`readied in ${pickTime / 1000}\`` : '❌'
+            ready ? `✅ \`readied in ${pickTime / 1000}\`` : '❌',
           )
           .join('\n'),
         inline: true,

--- a/src/commands/stack/stacking.ts
+++ b/src/commands/stack/stacking.ts
@@ -24,9 +24,12 @@ export const stackSetup = async (
   interaction: ChatInputCommandInteraction | ButtonInteraction,
   playerArray: PlayerObject[],
   pickTime: number,
-  oldMessage?: Message<true>
+  oldMessage?: Message<true>,
 ) => {
-  interaction.deferReply();
+  const needsAck = !interaction.replied && !interaction.deferred;
+  if (needsAck) {
+    interaction.deferReply();
+  }
   const guildId = getGuildId(interaction);
   const guildSettings = await getGuildFromDb(guildId);
   const isStrictPicking = guildSettings.strictPicking;
@@ -35,7 +38,9 @@ export const stackSetup = async (
   if (!oldMessage) {
     await pThreadCreator(interaction, message);
   }
-  await interaction.deleteReply();
+  if (needsAck) {
+    await interaction.deleteReply();
+  }
   stackExecute(playerArray, message, pickTime, interaction, isStrictPicking);
 };
 
@@ -45,7 +50,7 @@ const stackExecute = async (
   pickTime: number,
   interaction: ChatInputCommandInteraction | ButtonInteraction,
   isStrictPicking: boolean,
-  oldCanvas?: Canvas
+  oldCanvas?: Canvas,
 ) => {
   const available = availableRoles(playerArray);
   const nextUp = whosNext(playerArray);
@@ -73,7 +78,7 @@ const stackExecute = async (
 
   await message.edit({
     content: `**YOUR TURN TO PICK ${getNameWithPing(
-      nextUp.user
+      nextUp.user,
     )}!**\nIf you do not pick you will be assigned ${assignedRole} in <t:${
       time + pickTime + spaghettiTime
     }:R>`,
@@ -89,9 +94,9 @@ const stackExecute = async (
     componentType: ComponentType.Button,
   });
 
-  collector.on('collect', async i => {
+  collector.on('collect', async (i) => {
     console.log(
-      `${i.user.username} clicked ${i.customId} for ${nextUp.user.username}`
+      `${i.user.username} clicked ${i.customId} for ${nextUp.user.username}`,
     );
     if (isStrictPicking) {
       const isAppropriateInteraction = strictPicking(i, nextUp, interaction);
@@ -122,7 +127,7 @@ const stackExecute = async (
     try {
       if (collector.endReason === 'time') {
         console.log(
-          `Autopicked picked ${assignedRole} for ${nextUp.user.username}`
+          `Autopicked picked ${assignedRole} for ${nextUp.user.username}`,
         );
       }
       if (nextUp.position === 'fill') {
@@ -134,7 +139,7 @@ const stackExecute = async (
         pickTime,
         interaction,
         isStrictPicking,
-        newCanvas
+        newCanvas,
       );
       return;
     } catch (error) {


### PR DESCRIPTION
This is based on https://github.com/snygghugo/ShortStack/pull/19. Please merge that one first.

Remove the following interactions:
- Having to press "Start Ready Checker" once everyone has joined. We now go to ready check as soon as there are 5 people in an LFS.
- Having to press "stack it" to start stacking. We now go to stacking as soon as everyone is ready. The lobby host is now the last person who clicks ready (or the force readyer) instead of who clicked "Stack it"

I also removed the cancel button during ready checks because it was never used.