### PR TITLE
Automatically ready the last user to join lfs

### DIFF
--- a/src/commands/lfs/lobby.ts
+++ b/src/commands/lfs/lobby.ts
@@ -103,11 +103,17 @@ export const setUp = async (
 
   const beginReadyCheck = async (
     i: ButtonInteraction | ModalMessageModalSubmitInteraction,
+    autoReadyUserId?: string,
   ) => {
     readyStarted = true;
     joinPhaseLocked = true;
     await ackAndDiscard(i);
-    await readyChecker(confirmedPlayers, dotaMessage, partyThread);
+    await readyChecker(
+      confirmedPlayers,
+      dotaMessage,
+      partyThread,
+      autoReadyUserId,
+    );
     setTimeout(() => collector.stop(), STRAY_CLICK_GRACE);
   };
 
@@ -134,7 +140,7 @@ export const setUp = async (
         confirmedPlayers.push({ user: i.user, preferences, nickname });
         await partyThread.members.add(i.user);
         if (confirmedPlayers.length >= 5) {
-          await beginReadyCheck(i);
+          await beginReadyCheck(i, i.user.id);
           return;
         }
         await i.update({
@@ -289,6 +295,7 @@ const readyChecker = async (
   confirmedPlayers: ConfirmedPlayer[],
   partyMessage: Message<true>,
   partyThread: AnyThreadChannel,
+  autoReadyUserId?: string,
 ) => {
   console.log('now we are in the ready checker');
   const {
@@ -299,8 +306,9 @@ const readyChecker = async (
   } = readyCheckerStrings;
   const readyArray = confirmedPlayers.map(({ user }) => ({
     user,
-    ready: false,
+    ready: autoReadyUserId !== undefined && user.id === autoReadyUserId,
     pickTime: 0,
+    autoReady: autoReadyUserId !== undefined && user.id === autoReadyUserId,
   }));
   const time = getTimestamp(1000);
   const miliTime = getTimestamp(1);

--- a/src/commands/lfs/view.ts
+++ b/src/commands/lfs/view.ts
@@ -144,8 +144,12 @@ export const readyEmbed = (readyArray: PlayerToReady[]) => {
       {
         name: BLANK,
         value: readyArray
-          .map(({ ready, pickTime }) =>
-            ready ? `✅ \`readied in ${pickTime / 1000}\`` : '❌',
+          .map(({ ready, pickTime, autoReady }) =>
+            ready
+              ? autoReady
+                ? '✅ `auto ready`'
+                : `✅ \`readied in ${pickTime / 1000}\``
+              : '❌',
           )
           .join('\n'),
         inline: true,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -34,6 +34,7 @@ export type PlayerToReady = {
   user: User | Dummy;
   ready: boolean;
   pickTime: number;
+  autoReady?: boolean;
 };
 
 export type HugoData = {


### PR DESCRIPTION
This is based on https://github.com/snygghugo/ShortStack/pull/20. Please merge that one first.

The last user to join an lfs will be automatically set to ready. This will not be in effect when using dummy or /lfs (to add 4 people and yourself).

This will perhaps be controversial among the users. The intent with this, along with https://github.com/snygghugo/ShortStack/pull/19, is to enforce certain expectations on the users joining the stack. You cannot greedily hog a spot despite not being fully ready and then rely on your 3 ready check grace period to actually be ready.