### PR TITLE
Fix: Defer interactions before slow work

### DIFF
--- a/src/commands/lfs.ts
+++ b/src/commands/lfs.ts
@@ -19,22 +19,25 @@ export const data = new SlashCommandBuilder()
   .addUserOption(addUser)
   .addUserOption(addUser)
   .addUserOption(addUser)
-  .addIntegerOption(option =>
+  .addIntegerOption((option) =>
     option
       .setName('timelimit')
       .setDescription('How long can you wait for a Stack?')
       .setRequired(false)
       .setMinValue(5)
-      .setMaxValue(120)
+      .setMaxValue(120),
   );
 
 export const execute = async (interaction: ChatInputCommandInteraction) => {
+  await interaction.deferReply();
+
   const confirmedPlayers = await createConfirmedPlayers(interaction);
   if (!confirmedPlayers) {
-    interaction.reply('Please provide unique players!\nLove, **ShortStack!**');
+    await interaction.editReply(
+      'Please provide unique players!\nLove, **ShortStack!**',
+    );
     return;
   }
-  await interaction.deferReply();
   await interaction.deleteReply();
   await setUp(interaction, confirmedPlayers);
 };

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -57,6 +57,8 @@ export const data = new SlashCommandBuilder()
   );
 
 export const execute = async (interaction: ChatInputCommandInteraction) => {
+  await interaction.deferReply();
+
   const type = interaction.options.getSubcommand();
   const guildId = getGuildId(interaction);
   const guildSettings = await getGuildFromDb(guildId);
@@ -72,12 +74,12 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
           : [];
 
         if (!idMatches) {
-          await interaction.reply('No valid users entered');
+          await interaction.editReply('No valid users entered');
           break;
         }
         usersToAdd = [...idMatches.map((m) => m.groups!.id)];
       } else if (guildSettings.queue.includes(interaction.user.id)) {
-        await interaction.reply("You're already in the queue!");
+        await interaction.editReply("You're already in the queue!");
         break;
       }
 
@@ -88,7 +90,7 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
       );
       const joinSIfMany = usersToAdd?.length > 1 ? 's' : '';
       const joinPronoun = joinUsersString ? `Queuer${joinSIfMany}` : "You're";
-      await interaction.reply(
+      await interaction.editReply(
         `${joinPronoun} in! Queue looks like this:\n${joinMentionLines.join(
           '\n',
         )}`,
@@ -104,7 +106,7 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
           ? [...usersString.matchAll(/<@!?(?<id>\d+)>/g)]
           : [];
         if (!idMatches) {
-          await interaction.reply('No valid users entered');
+          await interaction.editReply('No valid users entered');
           break;
         }
         usersToRemove = [...idMatches.map((m) => m.groups!.id)];
@@ -117,17 +119,18 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
       const sIfMany = usersToRemove.length > 1 ? 's' : '';
       const outPronoun = usersString ? `Queuer${sIfMany}` : "You're";
       const mentionLines = postLeaveGuildSettings.queue.map((id) => `<@${id}>`);
-      await interaction.reply(
+      await interaction.editReply(
         `${outPronoun} out! Queue looks like this:\n${mentionLines.join('\n')}`,
       );
       break;
     case QUEUE_OPTIONS.invoke:
-      if (guildSettings.queue.length < 1)
-        return interaction.reply('Queue is empty!');
+      if (guildSettings.queue.length < 1) {
+        await interaction.editReply('Queue is empty!');
+        break;
+      }
       const invokeesNeeded = interaction.options.getNumber('invokees');
       if (invokeesNeeded) {
-        interaction.deferReply();
-        interaction.deleteReply();
+        await interaction.deleteReply();
         const channel = await getChannel(
           guildSettings.yaposChannel,
           interaction,
@@ -149,9 +152,8 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
         await postInvokeGuildSettings.save();
         break;
       }
-      interaction.reply({
+      await interaction.editReply({
         content: 'That is not an appropriate number for a Dota 2 party!',
-        ephemeral: true,
       });
 
       break;

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -12,7 +12,7 @@ import { getGuildId } from '../utils/getters';
 export const data = new SlashCommandBuilder()
   .setName('settings')
   .setDescription('ShortStack settings')
-  .addSubcommand(subcommand =>
+  .addSubcommand((subcommand) =>
     subcommand
       .setName('stackschannel')
       .setDescription('Set where ShortStack publishes the stack stuff')
@@ -20,10 +20,10 @@ export const data = new SlashCommandBuilder()
         option
           .setName('stackschannel')
           .setDescription('Set where ShortStack publishes the stack stuff')
-          .setRequired(true)
-      )
+          .setRequired(true),
+      ),
   )
-  .addSubcommand(subcommand =>
+  .addSubcommand((subcommand) =>
     subcommand
       .setName('role')
       .setDescription('Set which role ShortStack @pings')
@@ -31,27 +31,27 @@ export const data = new SlashCommandBuilder()
         option
           .setName('role')
           .setDescription('Set which role ShortStack @pings')
-          .setRequired(true)
-      )
+          .setRequired(true),
+      ),
   )
-  .addSubcommand(subcommand =>
+  .addSubcommand((subcommand) =>
     subcommand
       .setName('strictpicking')
       .setDescription(
-        'Restrict everyone from being able to select roles for anyone'
+        'Restrict everyone from being able to select roles for anyone',
       )
       .addBooleanOption((option: SlashCommandBooleanOption) =>
         option
           .setName('strictpicking')
           .setDescription(
-            'Restrict everyone from being able to select roles for anyone'
+            'Restrict everyone from being able to select roles for anyone',
           )
-          .setRequired(true)
-      )
+          .setRequired(true),
+      ),
   );
 
 const throwIfNullOrUndefined = <Type>(
-  thingToCheck: Type | undefined | null
+  thingToCheck: Type | undefined | null,
 ) => {
   if (thingToCheck) {
     return thingToCheck;
@@ -60,9 +60,11 @@ const throwIfNullOrUndefined = <Type>(
 };
 
 export const execute = async (interaction: ChatInputCommandInteraction) => {
+  await interaction.deferReply();
+
   const guildId = getGuildId(interaction);
   const commandName = throwIfNullOrUndefined(
-    interaction.options.getSubcommand()
+    interaction.options.getSubcommand(),
   );
   const guildSettings = await getGuildFromDb(guildId);
   let reply = 'Nothing was changed!';
@@ -72,10 +74,10 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
       const stacksChannel = interaction.options.getChannel('stackschannel');
       if (!stacksChannel) throw new Error('Unable to get stacksChannel!');
       if (stacksChannel.type !== ChannelType.GuildText) {
-        return interaction.reply({
+        await interaction.editReply({
           content: 'Please choose a standard text channel!',
-          ephemeral: true,
         });
+        return;
       }
       guildSettings.yaposChannel = stacksChannel.id;
       reply = `Roger! In the future I will output the good stuff in ${stacksChannel}.`;
@@ -84,10 +86,10 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
       const role = interaction.options.getRole('role');
       if (!role) throw new Error('Unable to get role!');
       if (role.id === interaction.guildId) {
-        return interaction.reply({
+        await interaction.editReply({
           content: "Don't make me ping everyone please!",
-          ephemeral: true,
         });
+        return;
       }
       guildSettings.yaposRole = role.id;
       reply = `Roger! In the future I will ping ${role} when I set up a stack!`;
@@ -106,6 +108,6 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
       break;
   }
   await guildSettings.save();
-  interaction.reply({ content: reply, ephemeral: false });
+  await interaction.editReply({ content: reply });
   return;
 };

--- a/src/commands/stack.ts
+++ b/src/commands/stack.ts
@@ -18,7 +18,7 @@ const createPlayerArray = async (interaction: ChatInputCommandInteraction) => {
     try {
       const userToAdd = getUserFromInteractionOptions(interaction, 'p' + i);
       if (playerArray.some(({ user }) => user.id === userToAdd.id)) {
-        interaction.reply('Please provide 5 unique players!');
+        await interaction.editReply('Please provide 5 unique players!');
         return;
       }
       const preferences = await getUserPrefs(userToAdd.id);
@@ -36,7 +36,7 @@ const createPlayerArray = async (interaction: ChatInputCommandInteraction) => {
     } catch (error) {
       const errorMsg = (error as Error).message;
       console.error(error);
-      await interaction.reply({
+      await interaction.editReply({
         content:
           'Something went wrong when setting up the player array! ' + errorMsg,
         embeds: [],
@@ -63,12 +63,14 @@ export const data = new SlashCommandBuilder()
   .addUserOption(addUser)
   .addUserOption(addUser)
   .addUserOption(addUser)
-  .addIntegerOption(option =>
-    option.setName('time').setDescription('Pick time')
+  .addIntegerOption((option) =>
+    option.setName('time').setDescription('Pick time'),
   );
 export const execute = async (interaction: ChatInputCommandInteraction) => {
+  await interaction.deferReply();
+
   const pickTime = interaction.options.getInteger('time') || STANDARD_TIME;
   const playerArray = await createPlayerArray(interaction);
   if (!playerArray) return;
-  stackSetup(interaction, playerArray, pickTime);
+  await stackSetup(interaction, playerArray, pickTime);
 };

--- a/src/commands/stack/stacking.ts
+++ b/src/commands/stack/stacking.ts
@@ -26,22 +26,38 @@ export const stackSetup = async (
   pickTime: number,
   oldMessage?: Message<true>,
 ) => {
-  const needsAck = !interaction.replied && !interaction.deferred;
-  if (needsAck) {
-    interaction.deferReply();
+  let message: Message<true> | undefined = oldMessage;
+  try {
+    const guildId = getGuildId(interaction);
+    const guildSettings = await getGuildFromDb(guildId);
+    const isStrictPicking = guildSettings.strictPicking;
+    const channel = await getChannel(guildSettings.yaposChannel, interaction);
+    message = oldMessage || (await channel.send('Setting up shop...'));
+    if (!oldMessage) {
+      await pThreadCreator(interaction, message);
+    }
+    if (interaction.deferred) {
+      await interaction.deleteReply();
+    }
+    await stackExecute(
+      playerArray,
+      message,
+      pickTime,
+      interaction,
+      isStrictPicking,
+    );
+  } catch (error) {
+    console.error('stack setup/render failed:', error);
+    await message
+      ?.edit({
+        content:
+          'Something went wrong while setting up the stack. Please try /stack again.',
+        components: [],
+      })
+      .catch((editError) =>
+        console.error('Failed to report stack error to channel:', editError),
+      );
   }
-  const guildId = getGuildId(interaction);
-  const guildSettings = await getGuildFromDb(guildId);
-  const isStrictPicking = guildSettings.strictPicking;
-  const channel = await getChannel(guildSettings.yaposChannel, interaction);
-  const message = oldMessage || (await channel.send('Setting up shop...'));
-  if (!oldMessage) {
-    await pThreadCreator(interaction, message);
-  }
-  if (needsAck) {
-    await interaction.deleteReply();
-  }
-  stackExecute(playerArray, message, pickTime, interaction, isStrictPicking);
 };
 
 const stackExecute = async (
@@ -59,6 +75,7 @@ const stackExecute = async (
   const art = new AttachmentBuilder(await newCanvas.encode('png'), {
     name: 'dota-map.png',
   });
+
   if (!nextUp) {
     await message.edit({
       content: 'All done!',
@@ -123,7 +140,7 @@ const stackExecute = async (
     collector.stop();
   });
 
-  collector.on('end', () => {
+  collector.on('end', async () => {
     try {
       if (collector.endReason === 'time') {
         console.log(
@@ -133,7 +150,7 @@ const stackExecute = async (
       if (nextUp.position === 'fill') {
         nextUp.artTarget = false;
       }
-      stackExecute(
+      await stackExecute(
         playerArray,
         message,
         pickTime,
@@ -143,8 +160,12 @@ const stackExecute = async (
       );
       return;
     } catch (error) {
-      message.edit('There was an error, baby!  ' + error);
       console.log(error);
+      await message
+        .edit('There was an error, baby!  ' + error)
+        .catch((editError) =>
+          console.error('Failed to report stack error to channel:', editError),
+        );
     }
   });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ client.once('ready', async () => {
   // transferDb(); if I need to update something form the JSON settings
 });
 
-client.on('interactionCreate', async interaction => {
+client.on('interactionCreate', async (interaction) => {
   if (!interaction.isChatInputCommand()) return;
   if (interaction.channel?.type !== ChannelType.GuildText) {
     await interaction.reply({
@@ -57,15 +57,33 @@ client.on('interactionCreate', async interaction => {
   if (!command) return;
 
   try {
-    command.execute(interaction);
+    await command.execute(interaction);
   } catch (error) {
     console.error(error);
-    await interaction.reply({
-      content: 'There was an error while executing this command!',
-      ephemeral: true,
-      components: [],
-    });
+    try {
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({
+          content: 'There was an error while executing this command!',
+          components: [],
+        });
+      } else {
+        await interaction.reply({
+          content: 'There was an error while executing this command!',
+          ephemeral: true,
+          components: [],
+        });
+      }
+    } catch (replyError) {
+      console.error('Failed to send error reply to interaction:', replyError);
+    }
   }
+});
+
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled promise rejection:', reason);
+});
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught exception:', error);
 });
 
 client.login(token);


### PR DESCRIPTION
Some slash commands would get stuck due to slow database/Discord work (preference lookups, nicknames, guild settings). Discord has a 3 second deadline for acknowledging an interaction. After 3 seconds the interaction dies and the bot throws DiscordAPIError. Because that call wasn't awaited, it became an unhandled exception that crashed the process.

This PR will acknowledge the interaction first, then do the work. It will also wrap stackSetup in error handling, which prevents the process from crashing if an error is thrown in the future.

I was able to confirm this by reproducing the error with testing code that added a 4 second delay which re-created the error.